### PR TITLE
Webhook-driven cache revalidation

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+
+// Set this secret in your Contentful webhook and as an env var
+const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
+
+export async function POST(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const secret = searchParams.get('secret');
+  const path = searchParams.get('path');
+
+  if (!secret || secret !== REVALIDATE_SECRET) {
+    return NextResponse.json({ message: 'Invalid secret' }, { status: 401 });
+  }
+  if (!path) {
+    return NextResponse.json({ message: 'Missing path' }, { status: 400 });
+  }
+
+  try {
+    await revalidatePath(path);
+    return NextResponse.json({ revalidated: true, now: Date.now(), path });
+  } catch (err) {
+    return NextResponse.json({ message: 'Error revalidating', error: String(err) }, { status: 500 });
+  }
+}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -7,18 +7,26 @@ const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
 export async function POST(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const secret = searchParams.get('secret');
-  const path = searchParams.get('path');
-
+  // Ignore the 'path' param, always revalidate the homepage and all main sections
   if (!secret || secret !== REVALIDATE_SECRET) {
     return NextResponse.json({ message: 'Invalid secret' }, { status: 401 });
   }
-  if (!path) {
-    return NextResponse.json({ message: 'Missing path' }, { status: 400 });
-  }
 
   try {
-    await revalidatePath(path);
-    return NextResponse.json({ revalidated: true, now: Date.now(), path });
+    // Revalidate the homepage and all main dynamic sections
+    await Promise.all([
+      revalidatePath('/'),
+      revalidatePath('/blog'),
+      revalidatePath('/past-events'),
+      revalidatePath('/upcoming-events'),
+      revalidatePath('/search'),
+      revalidatePath('/tags'),
+      // Optionally, revalidate all blog, past-events, and upcoming-events dynamic routes
+      revalidatePath('/blog', 'layout'),
+      revalidatePath('/past-events', 'layout'),
+      revalidatePath('/upcoming-events', 'layout'),
+    ]);
+    return NextResponse.json({ revalidated: true, now: Date.now(), paths: ['/', '/blog', '/past-events', '/upcoming-events', '/search', '/tags'] });
   } catch (err) {
     return NextResponse.json({ message: 'Error revalidating', error: String(err) }, { status: 500 });
   }

--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -182,8 +182,6 @@ export async function generateStaticParams(): Promise<
   return [...localParams, ...contentfulParams];
 }
 
-export const revalidate = 60;
-
 export default async function PostPage({ params }: PostPageProps) {
   const post = await getPostFromParams(params);
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -14,8 +14,6 @@ export const metadata: Metadata = {
   description: "Blogs and articles published by BAC members.",
 };
 
-export const revalidate = 60;
-
 const POSTS_PER_PAGE = 10;
 
 interface BlogPageProps {

--- a/app/past-events/[...slug]/page.tsx
+++ b/app/past-events/[...slug]/page.tsx
@@ -11,8 +11,6 @@ import { siteConfig } from "@/config/site";
 import { sortPosts } from "@/lib/utils";
 import { CommentSection } from "@/components/comment-section";
 
-export const revalidate = 60;
-
 interface PostPageProps {
   params: {
     slug: string[];

--- a/app/past-events/page.tsx
+++ b/app/past-events/page.tsx
@@ -12,8 +12,6 @@ export const metadata: Metadata = {
   description: "An archive of past events organised by BAC",
 };
 
-export const revalidate = 60;
-
 const POSTS_PER_PAGE = 10;
 
 interface BlogPageProps {

--- a/app/upcoming-events/[...slug]/page.tsx
+++ b/app/upcoming-events/[...slug]/page.tsx
@@ -11,8 +11,6 @@ import { Metadata } from "next";
 import { siteConfig } from "@/config/site";
 import { sortPosts } from "@/lib/utils";
 
-export const revalidate = 60;
-
 interface PostPageProps {
   params: {
     slug: string[];

--- a/app/upcoming-events/page.tsx
+++ b/app/upcoming-events/page.tsx
@@ -12,8 +12,6 @@ export const metadata: Metadata = {
   description: "Join our events and meetups in Bengaluru!",
 };
 
-export const revalidate = 60;
-
 const POSTS_PER_PAGE = 10;
 
 interface BlogPageProps {


### PR DESCRIPTION
- Switched from time-based ISR (revalidate = 60) to on-demand revalidation for all Contentful-powered pages (blog, past-events, upcoming-events).
- Added a secure API route (/api/revalidate) that revalidates the homepage and all main sections (blog, past-events, upcoming-events, search, tags) on Contentful webhook triggers.
- Updated Contentful webhook instructions to use the new endpoint and secret.
- Removed all revalidate exports from relevant pages—site now updates instantly on content changes, with no unnecessary background revalidation.
- No changes required to Contentful fetch logic; **all caching and revalidation is now webhook-driven.**